### PR TITLE
Fix arm system cpu frequency retrieval

### DIFF
--- a/backend/utils/server_info.py
+++ b/backend/utils/server_info.py
@@ -54,7 +54,7 @@ class ServerInfo:
         cpu_info = {'usage': round(psutil.cpu_percent(interval=1, percpu=False), 2)}  # %
 
         # 检查是否是 Apple M系列芯片
-        if platform.system() == "Darwin" and "arm" in platform.machine().lower():
+        if platform.system() == 'Darwin' and 'arm' in platform.machine().lower():
             cpu_info['max_freq'] = 0
             cpu_info['min_freq'] = 0
             cpu_info['current_freq'] = 0

--- a/backend/utils/server_info.py
+++ b/backend/utils/server_info.py
@@ -53,11 +53,22 @@ class ServerInfo:
         """获取 CPU 信息"""
         cpu_info = {'usage': round(psutil.cpu_percent(interval=1, percpu=False), 2)}  # %
 
-        # CPU 频率信息，最大、最小和当前频率
-        cpu_freq = psutil.cpu_freq()
-        cpu_info['max_freq'] = round(cpu_freq.max, 2)  # MHz
-        cpu_info['min_freq'] = round(cpu_freq.min, 2)  # MHz
-        cpu_info['current_freq'] = round(cpu_freq.current, 2)  # MHz
+        # 检查是否是 Apple M系列芯片
+        if platform.system() == "Darwin" and "arm" in platform.machine().lower():
+            cpu_info['max_freq'] = 0
+            cpu_info['min_freq'] = 0
+            cpu_info['current_freq'] = 0
+        else:
+            try:
+                # CPU 频率信息，最大、最小和当前频率
+                cpu_freq = psutil.cpu_freq()
+                cpu_info['max_freq'] = round(cpu_freq.max, 2)  # MHz
+                cpu_info['min_freq'] = round(cpu_freq.min, 2)  # MHz
+                cpu_info['current_freq'] = round(cpu_freq.current, 2)  # MHz
+            except AttributeError:
+                cpu_info['max_freq'] = 0
+                cpu_info['min_freq'] = 0
+                cpu_info['current_freq'] = 0
 
         # CPU 逻辑核心数，物理核心数
         cpu_info['logical_num'] = psutil.cpu_count(logical=True)


### PR DESCRIPTION
Fix: Disable CPU frequency retrieval on macOS systems with Apple Silicon (closes #384)