### PR TITLE
添加respons_model统一返回

### DIFF
--- a/backend/common/response/response_schema.py
+++ b/backend/common/response/response_schema.py
@@ -128,14 +128,6 @@ class Links(BaseModel):
     prev: str|None= Field(None, description="上一页链接")
 
 
-# 定义分页信息模型
-class Pagination(BaseModel):
-    total: int = Field(..., description="总条数")
-    page: int = Field(..., description="当前页")
-    size: int = Field(..., description="每页数量")
-    total_pages: int = Field(..., description="总页数")
-
-
 # 动态创建组合模型的辅助函数
 def create_paged_response_model(item_model: Type[BaseModel]) -> Type[BaseModel]:
     # 创建内部 data 模型

--- a/backend/common/response/response_schema.py
+++ b/backend/common/response/response_schema.py
@@ -107,4 +107,56 @@ class ResponseBase:
         return MsgSpecJSONResponse({'code': res.code, 'msg': res.msg, 'data': data})
 
 
+# 动态创建模型的辅助函数
+def create_detail_response_model(data_model: Type[BaseModel]) -> Type[BaseModel]:
+    # 使用 Union 允许 data 字段既可以是单个实例也可以是列表
+    data_field_type = Optional[Union[data_model, List[data_model]]]
+
+    return create_model(
+        'DynamicCombinedModel',  # 新模型的名字
+        __base__=ResponseModel,  # 继承自 ResponseModel
+        data=(data_field_type, None)  # 更新 data 字段类型为给定的 data_model 或其列表
+    )
+
+
+# 定义链接信息模型
+class Links(BaseModel):
+    first: str= Field(..., description='首页链接')
+    last: str = Field(..., description="尾页链接")
+    self: str= Field(None, description="当前页链接")
+    next: str= Field(None, description="下一页链接")
+    prev: str|None= Field(None, description="上一页链接")
+
+
+# 定义分页信息模型
+class Pagination(BaseModel):
+    total: int = Field(..., description="总条数")
+    page: int = Field(..., description="当前页")
+    size: int = Field(..., description="每页数量")
+    total_pages: int = Field(..., description="总页数")
+
+
+# 动态创建组合模型的辅助函数
+def create_paged_response_model(item_model: Type[BaseModel]) -> Type[BaseModel]:
+    # 创建内部 data 模型
+    DataModel = create_model(
+        'DataModel',
+        items=(List[item_model], Field(default_factory=list, description="业务信息")),  # 列表，默认为空
+        total=(int, Field(..., description="总条数")),
+        page=(int, Field(..., description="当前页")),
+        size=(int, Field(..., description="每页数量")),
+        total_pages=(int, Field(..., description="总页数")),
+        links=(Links, Field(..., description="跳转链接")),
+    )
+
+    # 创建最终的 end 模型
+    EndModel = create_model(
+        'EndModel',
+        __base__=ResponseModel,  # 继承自 ResponseModel
+        data=(DataModel, Field(..., description="数据详情"))  # 添加 data 字段，类型为 DataModel
+    )
+
+    return EndModel
+
+
 response_base: ResponseBase = ResponseBase()


### PR DESCRIPTION
为```@router.func```的    ```response_model= ```字段提供了两个功能
 ```create_detail_response_model``` ：根据 基于```SchemaBase``` 的类提供返回详情的方法
 ```create_paged_response_model```： 根据 基于```backend/common/pagination._Page``` 类提供的返回方法
主要作用是在OpenAPI文档中能够针对返回字段解释部分的使用

具体使用举例：
```python
@router.get(
  '/{pk}', 
  summary='获取部门详情', 
  dependencies=[DependsJwtAuth],
  response_model=create_detail_response_model(GetDeptListDetails)
)
async def get_dept(pk: Annotated[int, Path(...)]) -> ResponseModel:
    dept = await dept_service.get(pk=pk)
    data = GetDeptListDetails(**select_as_dict(dept))
    return response_base.success(data=data)
```
和
```python
@router.get(
    '',
    summary='（模糊条件）分页获取所有角色',
    dependencies=[
        DependsJwtAuth,
        DependsPagination,
    ],
 response_model=create_detail_response_model(GetDeptListDetails)
)
async def get_pagination_roles(
    db: CurrentSession,
    name: Annotated[str | None, Query()] = None,
    status: Annotated[int | None, Query()] = None,
) -> ResponseModel:
    role_select = await role_service.get_select(name=name, status=status)
    page_data = await paging_data(db, role_select, GetRoleListDetails)
    return response_base.success(data=page_data)
```

我是这个项目的粉丝，这个项目的使用真的很舒服，让我少写了很多代码，同时我也是通过这个项目让我见识到了fastapi的强大，我也希望能够提供一些有用的贡献