### PR TITLE
Fix serialization when pagination is empty

### DIFF
--- a/backend/common/pagination.py
+++ b/backend/common/pagination.py
@@ -63,7 +63,7 @@ class _CustomPage(_PageDetails, AbstractPage[T], Generic[T]):
         total_pages = ceil(total / params.size)
         links = create_links(**{
             'first': {'page': 1, 'size': f'{size}'},
-            'last': {'page': f'{ceil(total / params.size)}', 'size': f'{size}'} if total > 0 else 1,
+            'last': {'page': f'{ceil(total / params.size)}', 'size': f'{size if total > 0 else 1}'},
             'next': {'page': f'{page + 1}', 'size': f'{size}'} if (page + 1) <= total_pages else None,
             'prev': {'page': f'{page - 1}', 'size': f'{size}'} if (page - 1) >= 1 else None,
         }).model_dump()


### PR DESCRIPTION
嗨 我又来了，我猜你是想这么写，因为在特定情况下：表中没有一条数据。的时候会遇到 
``` python
TypeError: starlette.datastructures.URL.include_query_params() argument after ** must be a mapping, not int
```