### PR TITLE
Fix filters for opera log query list

### DIFF
--- a/backend/app/admin/crud/crud_opera_log.py
+++ b/backend/app/admin/crud/crud_opera_log.py
@@ -9,7 +9,12 @@ from backend.app.admin.schema.opera_log import CreateOperaLogParam
 
 
 class CRUDOperaLogDao(CRUDPlus[OperaLog]):
-    async def get_list(self, username: str | None = None, status: int | None = None, ip: str | None = None) -> Select:
+    async def get_list(
+        self,
+        username: str | None = None,
+        status: int | None = None,
+        ip: str | None = None,
+    ) -> Select:
         """
         获取操作日志列表
 
@@ -20,12 +25,12 @@ class CRUDOperaLogDao(CRUDPlus[OperaLog]):
         """
         filters = {}
         if username is not None:
-            filters.update(username=f'%{username}%')
+            filters.update(username__like=f"%{username}%")
         if status is not None:
             filters.update(status=status)
         if ip is not None:
-            filters.update(ip=f'%{ip}%')
-        return await self.select_order('created_time', 'desc', **filters)
+            filters.update(ip__like=f"%{ip}%")
+        return await self.select_order("created_time", "desc", **filters)
 
     async def create(self, db: AsyncSession, obj_in: CreateOperaLogParam) -> None:
         """


### PR DESCRIPTION
将 `get_list` 方法的参数格式调整为多行以提高可读性，并将过滤条件中的 `username` 和 `ip` 字段的匹配方式从直接拼接字符串改为使用 `__like` 操作符。