### PR TITLE
增加针对动态字段的数据解析

### DIFF
--- a/backend/common/pagination.py
+++ b/backend/common/pagination.py
@@ -121,6 +121,20 @@ async def paging_data(db: AsyncSession, select: Select) -> dict[str, Any]:
     """
     paginated_data: _CustomPage = await apaginate(db, select)
     page_data = paginated_data.model_dump()
+
+    # 确保items中的每个对象都保留其所有属性（包括动态字段）
+    if 'items' in page_data and page_data['items']:
+        for i, item in enumerate(page_data['items']):
+            # 检查原始对象是否有__dict__属性（SQLAlchemy模型对象通常有）
+            if hasattr(paginated_data.items[i], '__dict__'):
+                # 获取原始对象的所有属性
+                obj_dict = paginated_data.items[i].__dict__
+                # 添加所有以'c'或'n'开头的动态字段（如c1-c20, n1-n20）
+                for key, value in obj_dict.items():
+                    if (key.startswith('c') or key.startswith('n')) and key[1:].isdigit():
+                        if key not in item:
+                            item[key] = value
+
     return page_data
 
 

--- a/backend/common/schema.py
+++ b/backend/common/schema.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, validate_email
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, validate_email, create_model
 
 from backend.core.conf import settings
 
@@ -126,3 +126,24 @@ class SchemaBase(BaseModel):
         use_enum_values=True,
         json_encoders={datetime: lambda x: x.strftime(settings.DATETIME_FORMAT)},
     )
+
+class SchemaBaseNoId(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+    
+    
+# 动态创建字段定义
+fields = {}
+for i in range(1, 21):
+    field_name = f'c{i}'
+    # 使用新版Pydantic的字段定义方式
+    fields[field_name] = (Optional[str], Field(default=None))
+for i in range(1, 21):
+    field_name = f'n{i}'
+    # 使用新版Pydantic的字段定义方式
+    fields[field_name] = (Optional[float], Field(default=None))
+
+# 使用 create_model 动态创建 SchemaBaseOut 类
+SchemaBaseOut = create_model(
+    'SchemaBaseOut',  # 模型名称
+    **fields  # 字段名和对应的类型及默认值
+)


### PR DESCRIPTION
我在工作中遇到了一个问题,就是针对动态的BaseModel 使用项目中的page_data方法并不能做到解析,这导致了,我的字段缺失,所以修改了如下方法, 希望wu可以增加进去. 我的应用场景是这样的
    class UserSchema(SchemaBase,SchemaBaseOut):
        name: str = Field(..., title="姓名")
        age: int = Field(..., title="年龄")
        sex: int = Field(..., title="性别")
        model_config = ConfigDict(from_attributes=True) 