### PR TITLE
Fix CLI openapi url in production environment

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -34,7 +34,7 @@ def run(host: str, port: int, reload: bool, workers: int | None) -> None:
     url = f'http://{host}:{port}'
     docs_url = url + settings.FASTAPI_DOCS_URL
     redoc_url = url + settings.FASTAPI_REDOC_URL
-    openapi_url = url + settings.FASTAPI_OPENAPI_URL
+    openapi_url = url + (settings.FASTAPI_OPENAPI_URL or '')
 
     panel_content = Text()
     panel_content.append(f'📝 Swagger 文档: {docs_url}\n', style='blue')


### PR DESCRIPTION
生产环境时, backend/cli.py 中, openapi_url = url + settings.FASTAPI_OPENAPI_URL 这一行会报错(此时settings.FASTAPI_OPENAPI_URL值为None), 修改为 openapi_url = url + (settings.FASTAPI_OPENAPI_URL or '')