### PR TITLE
Fix the subprocess check call failed in windows

### DIFF
--- a/backend/plugin/tools.py
+++ b/backend/plugin/tools.py
@@ -319,7 +319,9 @@ def install_requirements(plugin: str | None) -> None:
                 pip_install = [sys.executable, '-m', 'pip', 'install', '-r', requirements_file]
                 if settings.PLUGIN_PIP_CHINA:
                     pip_install.extend(['-i', settings.PLUGIN_PIP_INDEX_URL])
-                subprocess.check_call(ensurepip_install, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,shell=True)
+                subprocess.check_call(
+                    ensurepip_install, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True
+                )
                 subprocess.check_call(pip_install, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             except subprocess.CalledProcessError as e:
                 raise PluginInstallError(f'插件 {plugin} 依赖安装失败：{e}') from e

--- a/backend/plugin/tools.py
+++ b/backend/plugin/tools.py
@@ -319,7 +319,7 @@ def install_requirements(plugin: str | None) -> None:
                 pip_install = [sys.executable, '-m', 'pip', 'install', '-r', requirements_file]
                 if settings.PLUGIN_PIP_CHINA:
                     pip_install.extend(['-i', settings.PLUGIN_PIP_INDEX_URL])
-                subprocess.check_call(ensurepip_install, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                subprocess.check_call(ensurepip_install, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,shell=True)
                 subprocess.check_call(pip_install, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             except subprocess.CalledProcessError as e:
                 raise PluginInstallError(f'插件 {plugin} 依赖安装失败：{e}') from e


### PR DESCRIPTION
在subprocess.check_call()中添加shell=True参数，解决Windows系统下 执行python.exe ensurepip --upgrade时出现CalledProcessError(returncode 2)的问题

### 🔧 Technical Details
**Before:**
```python
subprocess.check_call([
    'D:\\path\\to\\.venv\\Scripts\\python.exe',
    '-m','ensurepip','--upgrade'
])
# ❌ Fails with CalledProcessError (returncode 2)

**Afater:**
subprocess.check_call([
    'D:\\path\\to\\.venv\\Scripts\\python.exe',
    '-m','ensurepip','--upgrade'
], shell=True)
# ✅ Works correctly on Windows
问题截图：
<img width="1574" height="417" alt="image" src="https://github.com/user-attachments/assets/f676193e-eb0a-4f92-8b50-aad8298f94e5" />
