### PR TITLE
Fix the user list query serialization

### DIFF
--- a/backend/app/admin/service/user_service.py
+++ b/backend/app/admin/service/user_service.py
@@ -73,7 +73,9 @@ class UserService:
         user_select = await user_dao.get_select(dept=dept, username=username, phone=phone, status=status)
         data = await paging_data(db, user_select)
         if data['items']:
-            data['items'] = select_join_serialize(data['items'], relationships=['User-m2o-Dept', 'User-m2m-Role'])
+            serialized_items = select_join_serialize(data['items'], relationships=['User-m2o-Dept', 'User-m2m-Role'])
+            # 确保返回的是列表，即使只有一个元素
+            data['items'] = [serialized_items] if not isinstance(serialized_items, list) else serialized_items
         return data
 
     @staticmethod


### PR DESCRIPTION
select_join_serialize 函数在只有一个元素时会返回单个字典对象而不是列表，PageData 模型定义中 items 字段要求是 Sequence[SchemaT] （序列类型，如列表），所以当只存在一个用户返回的时候会检验错误