### PR TITLE
Update the i18n language file init location

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,7 +1,1 @@
-from backend.common.i18n import i18n
-
 __version__ = '1.11.0'
-
-
-# 初始化 i18n
-i18n.load_locales()

--- a/backend/common/i18n.py
+++ b/backend/common/i18n.py
@@ -16,6 +16,7 @@ class I18n:
     def __init__(self) -> None:
         self.locales: dict[str, dict[str, Any]] = {}
         self.current_language: str = settings.I18N_DEFAULT_LANGUAGE
+        self.load_locales()
 
     def load_locales(self) -> None:
         """加载语言文本"""


### PR DESCRIPTION
i18n 已在 fastapi 注册期间导入，由于 i18n 为实例，所以会同时初始化 I18n 类