### PR TITLE
Fix captcha and user validation order logic error

### DIFF
--- a/backend/app/admin/service/auth_service.py
+++ b/backend/app/admin/service/auth_service.py
@@ -99,6 +99,7 @@ class AuthService:
         """
         user = None
         try:
+            await load_login_config(db)
             if settings.LOGIN_CAPTCHA_ENABLED:
                 if not obj.uuid or not obj.captcha:
                     raise errors.RequestError(msg=t('error.captcha.invalid'))
@@ -110,9 +111,6 @@ class AuthService:
                 await redis_client.delete(f'{settings.LOGIN_CAPTCHA_REDIS_PREFIX}:{obj.uuid}')
 
             user, days_remaining = await self.user_verify(db, obj.username, obj.password)
-
-            await load_login_config(db)
-
             await user_dao.update_login_time(db, obj.username)
             await db.refresh(user)
             access_token_data = await create_access_token(


### PR DESCRIPTION
#1064 
调整登录流程中验证码验证与用户凭证验证的顺序，先进行验证码校验再验证用户身份，避免在验证码无效时仍执行用户查询操作，提升安全性和逻辑正确性。