### PR TITLE
Fix duplicate log reporting in OTEL

### DIFF
--- a/backend/common/observability/otel.py
+++ b/backend/common/observability/otel.py
@@ -113,7 +113,9 @@ def init_otel(app: FastAPI) -> None:
 
     AsyncioInstrumentor().instrument()
     HTTPXClientInstrumentor().instrument()
-    LoggingInstrumentor().instrument(set_logging_format=True)
+    # 禁止自动将 OTel handler 安装到 stdlib root logger，
+    # 避免与上面注册的 LoggingHandler（loguru sink）重复推送。
+    LoggingInstrumentor().instrument(set_logging_format=True, enable_log_auto_instrumentation=False)
     RedisInstrumentor.instrument_client(client=redis_client)  # type: ignore
     SQLAlchemyInstrumentor().instrument(engine=async_engine.sync_engine)
     FastAPIInstrumentor.instrument_app(app)


### PR DESCRIPTION
在loki中会重复上报日志

```
1783484811450	2026-07-08T04:26:51.450Z	2026-07-08 12:26:51.449 | INFO     | cdbdf6b74479985dbc7a782b2a21b8a9 | - | 146.56.222.94   | POST     | 200    | /api/v1/counseling/im-callback/rtc | 7.538ms
1783484811449	2026-07-08T04:26:51.449Z	2026-07-08 12:26:51.449 | INFO     | cdbdf6b74479985dbc7a782b2a21b8a9 | - | RTC 回调处理结果: command=Call.CallbackAfterRecordChanged matched=False
1783484811449	2026-07-08T04:26:51.449Z	RTC 回调处理结果: command=Call.CallbackAfterRecordChanged matched=False
1783484811449	2026-07-08T04:26:51.449Z	2026-07-08 12:26:51.449 | INFO     | cdbdf6b74479985dbc7a782b2a21b8a9 | - | RTC 录制状态变更回调: 非核心事件 vod_stop (VOD 录制任务结束)，跳过
1783484811449	2026-07-08T04:26:51.449Z	RTC 录制状态变更回调: 非核心事件 vod_stop (VOD 录制任务结束)，跳过
1783484811449	2026-07-08T04:26:51.449Z	2026-07-08 12:26:51.448 | INFO     | cdbdf6b74479985dbc7a782b2a21b8a9 | - | RTC 回调 CallbackCommand=Call.CallbackAfterRecordChanged
```