### PR TITLE
fix: 移除 SchemaBase 已弃用的 json_encoders

### DIFF
--- a/backend/common/schema.py
+++ b/backend/common/schema.py
@@ -1,13 +1,141 @@
 from datetime import datetime
-from typing import Annotated, Any
+from types import UnionType
+from typing import Annotated, Any, Union, get_args, get_origin, get_type_hints
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, validate_email
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    GetCoreSchemaHandler,
+    SerializerFunctionWrapHandler,
+    validate_email,
+)
+from pydantic_core import PydanticUndefined, core_schema
+from typing_extensions import TypeAliasType
 
 from backend.common.enums import PrimaryKeyType
 from backend.core.conf import settings
 from backend.utils.timezone import timezone
 
 CustomPhoneNumber = Annotated[str, Field(pattern=r'^1[3-9]\d{9}$')]
+
+
+def _serialize_datetime(value: datetime) -> str:
+    if value.tzinfo is not None and value.tzinfo != timezone.tz_info:
+        return timezone.to_str(timezone.from_datetime(value))
+    return timezone.to_str(value)
+
+
+def _serialize_any_datetime(value: Any, handler: SerializerFunctionWrapHandler) -> Any:
+    if isinstance(value, datetime):
+        return _serialize_datetime(value)
+    return handler(value)
+
+
+def _contains_datetime(annotation: Any) -> bool:
+    if isinstance(annotation, TypeAliasType):
+        return _contains_datetime(annotation.__value__)
+    if isinstance(annotation, type) and issubclass(annotation, datetime):
+        return True
+    return any(_contains_datetime(arg) for arg in get_args(annotation))
+
+
+def _unwrap_annotated(annotation: Any) -> Any:
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    return annotation
+
+
+def _is_any_field(annotation: Any) -> bool:
+    annotation = _unwrap_annotated(annotation)
+    if isinstance(annotation, TypeAliasType):
+        return _is_any_field(annotation.__value__)
+    if annotation is Any:
+        return True
+    if get_origin(annotation) in (Union, UnionType):
+        return any(_is_any_field(arg) for arg in get_args(annotation) if arg is not type(None))
+    return False
+
+
+def _set_datetime_serializer(schema: Any, handler: GetCoreSchemaHandler) -> None:
+    if isinstance(schema, dict):
+        if 'serialization' in schema:
+            return
+        if schema.get('type') == 'definition-ref':
+            _set_datetime_serializer(handler.resolve_ref_schema(schema), handler)
+            return
+        if schema.get('type') == 'datetime' and 'serialization' not in schema:
+            schema['serialization'] = core_schema.plain_serializer_function_ser_schema(
+                _serialize_datetime,
+                when_used='json',
+            )
+        for value in schema.values():
+            _set_datetime_serializer(value, handler)
+    elif isinstance(schema, list):
+        for value in schema:
+            _set_datetime_serializer(value, handler)
+
+
+def _find_model_fields_schema(schema: Any, model_name: str) -> dict[str, Any]:
+    if isinstance(schema, dict):
+        if schema.get('type') == 'model-fields' and schema.get('model_name') == model_name:
+            return schema
+        for value in schema.values():
+            if fields := _find_model_fields_schema(value, model_name):
+                return fields
+    elif isinstance(schema, list):
+        for value in schema:
+            if fields := _find_model_fields_schema(value, model_name):
+                return fields
+    return {}
+
+
+def _set_annotation_datetime_serializer(
+    schema: Any,
+    annotation: Any,
+    handler: GetCoreSchemaHandler,
+) -> None:
+    if _is_any_field(annotation):
+        if 'serialization' not in schema:
+            schema['serialization'] = core_schema.wrap_serializer_function_ser_schema(
+                _serialize_any_datetime,
+                when_used='json',
+            )
+    elif _contains_datetime(annotation):
+        _set_datetime_serializer(schema, handler)
+
+
+def _get_computed_return_annotation(field_info: Any) -> Any:
+    wrapped_property = field_info.wrapped_property
+    function = getattr(wrapped_property, 'fget', None) or getattr(wrapped_property, 'func', None)
+    if function is not None:
+        try:
+            return get_type_hints(function).get('return', field_info.return_type)
+        except (NameError, TypeError):
+            pass
+    return field_info.return_type
+
+
+def _set_model_datetime_serializers(
+    schema: core_schema.CoreSchema,
+    model: type[BaseModel],
+    handler: GetCoreSchemaHandler,
+) -> None:
+    model_fields_schema = _find_model_fields_schema(schema, model.__name__)
+    field_schemas = model_fields_schema.get('fields', {})
+    for field_name, field_info in model.__pydantic_fields__.items():
+        if field_schema := field_schemas.get(field_name, {}).get('schema'):
+            _set_annotation_datetime_serializer(field_schema, field_info.annotation, handler)
+
+    computed_schemas = {
+        field['property_name']: field['return_schema'] for field in model_fields_schema.get('computed_fields', [])
+    }
+    for field_name, field_info in model.__pydantic_computed_fields__.items():
+        if field_schema := computed_schemas.get(field_name):
+            annotation = _get_computed_return_annotation(field_info)
+            if annotation is not PydanticUndefined:
+                _set_annotation_datetime_serializer(field_schema, annotation, handler)
 
 
 class CustomEmailStr(EmailStr):
@@ -23,14 +151,17 @@ class SchemaBase(BaseModel):
 
     model_config = ConfigDict(
         use_enum_values=True,
-        json_encoders={
-            datetime: lambda x: (
-                timezone.to_str(timezone.from_datetime(x))
-                if x.tzinfo is not None and x.tzinfo != timezone.tz_info
-                else timezone.to_str(x)
-            ),
-        },
     )
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        schema = handler(source_type)
+        _set_model_datetime_serializers(schema, source_type, handler)
+        return schema
 
     if PrimaryKeyType.snowflake == settings.DATABASE_PK_MODE:
         from pydantic import field_serializer

--- a/tests/test_common_schema.py
+++ b/tests/test_common_schema.py
@@ -1,0 +1,272 @@
+import os
+import subprocess
+import sys
+import warnings
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated, Any
+
+from pydantic import GetCoreSchemaHandler, HttpUrl, PlainSerializer, computed_field, field_serializer
+from pydantic_core import core_schema
+from typing_extensions import TypeAliasType
+
+from backend.common.enums import StatusType
+from backend.common.schema import SchemaBase
+from backend.utils.timezone import timezone
+
+
+class _SerializationSchema(SchemaBase):
+    happened_at: datetime
+    optional_value: str | None = None
+    status: StatusType
+    steps: list[int]
+
+
+class _ContainerSchema(SchemaBase):
+    typed_values: list[datetime]
+    typed_mapping: dict[str, datetime]
+    any_value: Any
+    optional_any: Any | None
+    any_mapping: dict[str, Any]
+
+
+class _SpecializedSerializerSchema(SchemaBase):
+    payload: bytes
+
+    @field_serializer('payload', when_used='json')
+    def serialize_payload(self, value: bytes) -> str:
+        return value.decode()
+
+
+SerializedUrl = Annotated[HttpUrl, PlainSerializer(lambda value: str(value), return_type=str)]
+
+
+class _PlainSerializerSchema(SchemaBase):
+    homepage: SerializedUrl
+
+
+class _WrappedDatetime:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            lambda value: value,
+            core_schema.datetime_schema(),
+            serialization=core_schema.wrap_serializer_function_ser_schema(
+                lambda value, next_handler: f'wrapped<{next_handler(value)}>',
+                when_used='json',
+            ),
+        )
+
+
+class _DateLike:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            lambda value: value,
+            core_schema.datetime_schema(),
+        )
+
+
+class _CustomCoreSerializerSchema(SchemaBase):
+    happened_at: _WrappedDatetime
+    date_like: _DateLike
+
+
+DatetimeAlias = TypeAliasType('DatetimeAlias', datetime)
+
+
+class _AliasAndComputedSchema(SchemaBase):
+    happened_at: DatetimeAlias
+
+    @computed_field
+    @property
+    def computed_at(self) -> datetime:
+        return self.happened_at
+
+
+class _NestedSchema(SchemaBase):
+    visible: str
+    hidden: str
+
+
+class _NestedChildSchema(_NestedSchema):
+    child_only: str
+
+
+class _NestedContainerSchema(SchemaBase):
+    nested: _NestedSchema
+
+
+def test_schema_base_import_has_no_deprecated_json_encoder_warning() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(repo_root)
+    script = (
+        'import warnings; '
+        'from pydantic.warnings import PydanticDeprecatedSince20; '
+        'warnings.simplefilter("error", PydanticDeprecatedSince20); '
+        'from backend.common.schema import SchemaBase'
+    )
+
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_schema_base_preserves_field_filters_and_datetime_format() -> None:
+    happened_at = datetime(2026, 7, 13, 8, 30, tzinfo=UTC)
+    schema = _SerializationSchema(happened_at=happened_at, status=1, steps=[1])
+    serialized_time = timezone.to_str(timezone.from_datetime(happened_at))
+
+    assert schema.model_dump(exclude={'steps'}) == {
+        'happened_at': happened_at,
+        'optional_value': None,
+        'status': 1,
+    }
+    assert schema.model_dump(mode='json', include={'happened_at'}) == {
+        'happened_at': serialized_time,
+    }
+    assert schema.model_dump(mode='json', exclude={'steps'}, exclude_none=True) == {
+        'happened_at': serialized_time,
+        'status': 1,
+    }
+
+
+def test_schema_base_preserves_typed_and_any_container_datetime_formats() -> None:
+    happened_at = datetime(2026, 7, 13, 8, 30, tzinfo=UTC)
+    schema = _ContainerSchema(
+        typed_values=[happened_at],
+        typed_mapping={'happened_at': happened_at},
+        any_value=happened_at,
+        optional_any=happened_at,
+        any_mapping={'happened_at': happened_at},
+    )
+    serialized_time = timezone.to_str(timezone.from_datetime(happened_at))
+
+    assert schema.model_dump(mode='json') == {
+        'typed_values': [serialized_time],
+        'typed_mapping': {'happened_at': serialized_time},
+        'any_value': serialized_time,
+        'optional_any': serialized_time,
+        'any_mapping': {'happened_at': '2026-07-13T08:30:00Z'},
+    }
+
+
+def test_schema_base_preserves_nested_filters_and_declared_type_boundary() -> None:
+    filtered = _NestedContainerSchema(
+        nested=_NestedSchema(visible='yes', hidden='no'),
+    )
+    child = _NestedContainerSchema(
+        nested=_NestedChildSchema(visible='yes', hidden='no', child_only='private'),
+    )
+    include = {'nested': {'visible'}}
+    exclude = {'nested': {'hidden'}}
+
+    assert filtered.model_dump(include=include) == {'nested': {'visible': 'yes'}}
+    assert filtered.model_dump(mode='json', exclude=exclude) == {'nested': {'visible': 'yes'}}
+    assert child.model_dump() == {'nested': {'visible': 'yes', 'hidden': 'no'}}
+    assert child.model_dump(mode='json') == {'nested': {'visible': 'yes', 'hidden': 'no'}}
+
+
+def test_schema_base_preserves_serialization_json_schema() -> None:
+    schema = _SerializationSchema.model_json_schema(mode='serialization')
+    properties = schema['properties']
+
+    assert properties['happened_at']['type'] == 'string'
+    assert properties['happened_at']['format'] == 'date-time'
+    assert properties['status']['$ref'].startswith('#/$defs/')
+    assert properties['steps']['type'] == 'array'
+    assert properties['steps']['items']['type'] == 'integer'
+
+
+def test_schema_base_serializes_enum_without_warning() -> None:
+    schema = _SerializationSchema(
+        happened_at=datetime(2026, 7, 13, 8, 30, tzinfo=UTC),
+        status=1,
+        steps=[],
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        assert schema.model_dump()['status'] == 1
+        assert schema.model_dump(mode='json')['status'] == 1
+
+    assert caught == []
+
+
+def test_schema_base_allows_specialized_serializers_without_warning() -> None:
+    decorated = _SpecializedSerializerSchema(payload=b'ok')
+    annotated = _PlainSerializerSchema(homepage='https://example.com')
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        assert decorated.model_dump(mode='json') == {'payload': 'ok'}
+        assert annotated.model_dump(mode='json') == {'homepage': 'https://example.com/'}
+
+    assert caught == []
+
+
+def test_schema_base_does_not_change_custom_core_serializer_handler() -> None:
+    happened_at = datetime(2026, 7, 13, 8, 30, tzinfo=UTC)
+    schema = _CustomCoreSerializerSchema(happened_at=happened_at, date_like=happened_at)
+
+    assert schema.model_dump(mode='json') == {
+        'happened_at': 'wrapped<2026-07-13T08:30:00Z>',
+        'date_like': '2026-07-13T08:30:00Z',
+    }
+
+
+def test_schema_base_serializes_datetime_alias_and_computed_field() -> None:
+    happened_at = datetime(2026, 7, 13, 8, 30, tzinfo=UTC)
+    schema = _AliasAndComputedSchema(happened_at=happened_at)
+    serialized_time = timezone.to_str(timezone.from_datetime(happened_at))
+
+    assert schema.model_dump(mode='json') == {
+        'happened_at': serialized_time,
+        'computed_at': serialized_time,
+    }
+
+
+def test_schema_base_preserves_snowflake_id_serializer() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env['DATABASE_PK_MODE'] = 'snowflake'
+    env['PYTHONPATH'] = str(repo_root)
+    script = (
+        'from pydantic import ConfigDict; '
+        'from backend.common.schema import SchemaBase; '
+        'SnowflakeSchema = type('
+        '"SnowflakeSchema", '
+        '(SchemaBase,), '
+        '{"__annotations__": {"id": int}, "model_config": ConfigDict(from_attributes=True)}'
+        '); '
+        'assert SnowflakeSchema(id=9007199254740993).model_dump(mode="json") '
+        '== {"id": "9007199254740993"}'
+    )
+
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## 问题

项目已经依赖 `pydantic>=2.13.4`，但 `SchemaBase` 仍通过 `ConfigDict.json_encoders` 定制 datetime 输出。该配置从 Pydantic 2.0 起已弃用，并计划在 Pydantic 3.0 移除；Schema 子类生成 core schema 时会持续产生 `PydanticDeprecatedSince20` 告警。

参考：[Pydantic Custom serializers](https://docs.pydantic.dev/2.13/concepts/serialization/#custom-serializers)

## 原因

现有 encoder 不只是格式化一个顶层字段，它会根据字段声明的 core schema 处理：

- 普通 datetime 与 `list[datetime]`、`dict[str, datetime]` 等 typed 容器；
- datetime 类型别名、Optional/Union 与 computed field；
- 同时保留 `Any` 容器的 Pydantic 默认 ISO 行为。

因此不能简单替换为 model-level 或 wildcard field serializer：

- model-level wrap serializer 会干扰 Python mode 的 `model_dump(include/exclude=...)`；
- wildcard field serializer 只能直接识别顶层值，typed datetime 容器会退化为默认 ISO；
- 为 wildcard serializer 声明 `Any` 返回类型还会使 serialization JSON Schema 丢失 `type`、`format`、`$ref` 等信息；
- 盲目递归 core schema 则可能穿透已有自定义 serializer，改变其 handler 的输出。

## 解决方案

本 PR 移除 `json_encoders`，在 `SchemaBase.__get_pydantic_core_schema__()` 中按当前模型的字段声明精确注入 datetime JSON serializer：

- datetime 字段、typed 容器、类型别名和 computed field 继续输出项目时区格式；
- 顶层 `Any` / `Any | None` 在运行时为 datetime 时同样输出项目时区格式；
- `dict[str, Any]` 等 Any 容器内部仍保持 Pydantic ISO 8601；
- 遇到已有 `serialization` 时立即停止，不覆盖或改变 decorator、Annotated、custom core serializer；
- 保留 Python mode、嵌套 include/exclude、声明类型边界、枚举和 snowflake ID 行为；
- 保留原有 serialization JSON Schema，避免影响 FastAPI OpenAPI 响应契约。

## 测试

新增独立的公共 Schema 契约测试，不加载应用、数据库或 Redis，覆盖：

- 弃用告警消失；
- datetime 时区格式与 typed/Any 容器边界；
- include、exclude、exclude_none 与嵌套字段筛选；
- 父类型字段边界；
- serialization JSON Schema；
- enum、decorator/Annotated/custom core serializer；
- datetime 类型别名、computed field、Optional[Any]；
- snowflake ID serializer。

验证命令：

```bash
uv run pytest -q tests/test_common_schema.py
# 10 passed

uv run prek run --all-files
# all hooks passed
```
